### PR TITLE
FIX - 리뷰 팝업에서 ‘이 상품 다시보지 않기’ 버튼 눌렀을 때 내용없이 경고창이 뜨는 문제

### DIFF
--- a/views/pc/reviews/_new_popup.html.erb
+++ b/views/pc/reviews/_new_popup.html.erb
@@ -15,7 +15,7 @@
         </div>
       <% end %>
     <% end %>
-    <%= content_tag :div, '이 상품 다시 보지 않기', class: 'popup-item-not-view', data: {url: review_pending_reviews_path(sub_order_id: @review.sub_order_id)} %>
+    <%= content_tag :div, t('reviews.new.dont_show_this_product_again'), class: 'popup-item-not-view', data: {url: review_pending_reviews_path(sub_order_id: @review.sub_order_id), confirm_message: t('reviews.new.confirm_dont_show')} %>
     <div class="item-information-text">
       <% if !@review.product.name.blank? %>
         <div class="item-name"><%= @review.product.name %></div>


### PR DESCRIPTION
### 원인
- `confirm_message`가 누락되어있었기 때문에 빈 메세지 경고창이 뜨는 것이었음

### 수정 사항
- `confirm_message`를 추가해줌.

https://app.asana.com/0/222280601547638/247044287690053