### PR TITLE
REMOVE - 불필요해진 “SNS형 팝업 사용 여부” 옵션 제거

### DIFF
--- a/views/pc/products/reviews/_summary.html.erb
+++ b/views/pc/products/reviews/_summary.html.erb
@@ -23,13 +23,9 @@ reviews = product.meta_visible_reviews
               link_class = 'photo-review-new-window fade-from-grayscale'
               link_url = photo_review_popup_review_url(image.model.id, photo_index: image.mounted_as[5].to_i, external_widget: 1)
               target = '_blank'
-            elsif brand.review_enable_gallery_popup
+            else
               link_class = 'link-fullscreen-popup fade-from-grayscale'
               link_data = {url: photo_review_popup_review_path(image.model.id, photo_index: image.mounted_as[5].to_i)}
-            else
-              link_class = 'link-image-zoom fade-from-grayscale'
-              w, h = image.dimension
-              link_data = {url: image.url, width: w, height: h}
             end
           %>
           <li class="photo-review-thumbnail">

--- a/views/pc/reviews/_image_thumbnail.html.erb
+++ b/views/pc/reviews/_image_thumbnail.html.erb
@@ -7,13 +7,9 @@ if local_assigns[:external_widget]
   link_class = 'photo-review-new-window'
   link_url = photo_review_popup_review_url(review, photo_index: i, external_widget: 1)
   target = '_blank'
-elsif @brand.review_enable_gallery_popup
+else
   link_class = 'link-fullscreen-popup'
   link_data = {url: photo_review_popup_review_path(review, photo_index: i)}
-else
-  link_class = 'link-image-zoom'
-  w, h = image.dimension
-  link_data = {url: image.url, width: w, height: h}
 end
 %>
 <%= content_tag :li, class: local_assigns[:li_class] do %>


### PR DESCRIPTION
### 이유
- 모든 쇼핑몰이 true로 설정되어 있고, false로 바꿀 필요가 없음

### 제거 내용
- review_enable_gallery_popup storage 변수 및 사용하는 곳 모두 제거
- .link-image-zoom 관련 내용 제거 (`review_enable_gallery_popup`이 true인 경우에만 사용한다.)
- ImageZoom 관련 내용 제거 (`.link-image-zoom` 이 있을때만 사용한다.)

https://app.asana.com/0/75312375888163/308959848501467