### PR TITLE
FIX - 상품 링크 클릭시 이동하지 않는 문제

### DIFF
--- a/views/pc/reviews/index/custom/_review.html.erb
+++ b/views/pc/reviews/index/custom/_review.html.erb
@@ -1,17 +1,16 @@
-<%= content_tag_for :li, review, data: {product_url: review.product_url, expand_url: expand_review_path(review, widget_id: widget.id)} do %>
+<% product_url = review.product_url %>
+<%= content_tag_for :li, review, data: {expand_url: expand_review_path(review, widget_id: widget.id)} do %>
   <%= content_tag :div, class: 'review-content', data: {toggle: true} do %>
     <div class="review-content-summary">
       <% review_position = @first_review_position_in_page - review_counter if @first_review_position_in_page %>
       <div class="col index"><%= @first_review_position_in_page ? review_position : review.id %></div>
       <div class="col product-image">
-        <a class="image link-product">
+        <%= content_tag :a, class: 'image link-product link-iframe', data: {url: product_url} do %>
           <%= image_tag review.product_image_url, class: 'smooth', alt: review.product_name, width: 80, height: 80 %>
-        </a>
+        <% end %>
       </div>
       <div class="col product-name">
-        <a class="link-product">
-          <%= review.product_name %>
-        </a>
+        <%= content_tag :a, review.product_name, class: 'link-product link-iframe', data: {url: product_url} %>
       </div>
       <div class="col score">
         <div class="star-rating-container">


### PR DESCRIPTION
### 원인
- li.review 내부 혹은 li.product 내부의 link-product만 정상동작하도록 구현되어 있음
- https://github.com/crema/crema/commit/4ca9967d26e2020ee0d77814a89bb23f92b1114b 에서 갤러리형 리뷰는 li.review 사용하지 않고 구현함

### 수정 내용
- link-product가 상위 element와 무관하게 동작하도록 모두 link-iframe으로 교체
- link-product 클릭처리하는 js 삭제

https://app.asana.com/0/308959848501449/354047611930022