### PR TITLE
FIX - PC 갤러리형 위젯 안뜨는 문제 수정

### DIFF
--- a/views/pc/reviews/index/_galley.html.erb
+++ b/views/pc/reviews/index/_galley.html.erb
@@ -3,7 +3,7 @@
   <%= content_tag :div, class: "widget widget-reviews pagination-list" do %>
     <div class="widget-body index-thumbnail-container">
       111<%= render 'reviews/top_menu' %>
-      <%= render 'reviews/notices' if @brand.review_show_notice_every_board %>
+      <%= render 'reviews/notices' if widget.show_notices %>
       <% if @reviews.empty? %>
         <div class="no-data"><%= t('reviews.no_reviews') %></div>
       <% else %>


### PR DESCRIPTION
### 원인
- brand에서 review_show_notice_every_board 설정이 제거되고, widget에 show_notices로 대체된 것이 반영 안되어 있었음

### 해결
- widget.show_notices 를 사용하도록 수정

https://app.asana.com/0/search/308959848501449/362905307494823